### PR TITLE
Include schema.c in the generated tarball.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,6 +14,8 @@ build_recorder_SOURCES = \
 
 dist_noinst_HEADERS = *.h
 
+EXTRA_DIST = schema.c
+
 SCHEMA = ../doc/build-recorder-schema.ttl
 
 dist_data_DATA = $(SCHEMA)


### PR DESCRIPTION
Save users from having to install xxd to build build-recorder.